### PR TITLE
Fix/text bug on migrate page

### DIFF
--- a/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -471,8 +471,8 @@ function V2PairMigration({
                   <RowBetween>
                     <ThemedText.DeprecatedBody fontWeight={535} fontSize={14}>
                       <Trans>
-                        {{ name: { name: isNotUniswap ? 'SushiSwap' : 'V2' } }}{' '}
-                        {{ sym: invertPrice ? currency1.symbol : currency0.symbol }} Price:
+                        {isNotUniswap ? 'SushiSwap' : 'V2'}
+                        {invertPrice ? currency1.symbol : currency0.symbol} Price:
                       </Trans>{' '}
                       {invertPrice
                         ? `${v2SpotPrice?.invert()?.toSignificant(6)} ${currency0.symbol}`

--- a/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -471,8 +471,7 @@ function V2PairMigration({
                   <RowBetween>
                     <ThemedText.DeprecatedBody fontWeight={535} fontSize={14}>
                       <Trans>
-                        {isNotUniswap ? 'SushiSwap' : 'V2'}
-                        {invertPrice ? currency1.symbol : currency0.symbol} Price:
+                        {isNotUniswap ? 'SushiSwap' : 'V2'} {invertPrice ? currency1.symbol : currency0.symbol} Price:
                       </Trans>{' '}
                       {invertPrice
                         ? `${v2SpotPrice?.invert()?.toSignificant(6)} ${currency0.symbol}`


### PR DESCRIPTION
# Issue #7 

# Description
Fixed the the Text Bug " [Object Object] " displaying on the migrate page.

The {name: ...} and {sym: ...} syntax created objects, leading to the [object Object] issue.

