### PR TITLE
Display V2 pools in account drawer

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Pools/index.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Pools/index.tsx
@@ -14,6 +14,12 @@ import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { ThemedText } from 'theme/components'
 import { NumberType, useFormatter } from 'utils/formatNumbers'
+import JSBI from 'jsbi'
+import { useV2Pairs } from 'hooks/useV2Pairs'
+import { toV2LiquidityToken, useTrackedTokenPairs } from 'state/user/hooks'
+import { useTokenBalance, useTokenBalancesWithLoadingIndicator } from 'state/connection/hooks'
+import { Pair } from '@uniswap/v2-sdk'
+import { useTotalSupply } from 'hooks/useTotalSupply'
 
 import { ExpandoRow } from '../ExpandoRow'
 import { useToggleAccountDrawer } from '../hooks'
@@ -22,12 +28,6 @@ import PortfolioRow, { PortfolioSkeleton, PortfolioTabWrapper } from '../Portfol
 import { PositionInfo } from './cache'
 import { useFeeValues } from './hooks'
 import useMultiChainPositions from './useMultiChainPositions'
-import { useV2Pairs } from 'hooks/useV2Pairs'
-import { toV2LiquidityToken, useTrackedTokenPairs } from 'state/user/hooks'
-import { useTokenBalance, useTokenBalancesWithLoadingIndicator } from 'state/connection/hooks'
-import { Pair } from '@uniswap/v2-sdk'
-import { useTotalSupply } from 'hooks/useTotalSupply'
-import JSBI from 'jsbi'
 
 /**
  * Takes an array of PositionInfo objects (format used by the Ubeswap gql API).

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Pools/index.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Pools/index.tsx
@@ -56,7 +56,7 @@ export default function Pools({ account }: { account: string }) {
   const { positions, loading } = useMultiChainPositions(account)
   const filteredPositions = useFilterPossiblyMaliciousPositionInfo(positions)
   const [showClosed, toggleShowClosed] = useReducer((showClosed) => !showClosed, false)
-  const [showV2, toggleShowV2] = useReducer((show) => !show, false)
+  const [showV2, toggleShowV2] = useReducer((show) => !show, true)
 
   const [openPositions, closedPositions] = useMemo(() => {
     const openPositions: PositionInfo[] = []
@@ -98,10 +98,6 @@ export default function Pools({ account }: { account: string }) {
 
   const v2Pairs = useV2Pairs(liquidityTokensWithBalances.map(({ tokens }) => tokens))
   const allV2PairsWithLiquidity = v2Pairs.map(([, pair]) => pair).filter((v2Pair): v2Pair is Pair => Boolean(v2Pair))
-
-  useMemo(() => {
-    console.log({ closedPositions, allV2PairsWithLiquidity, openPositions })
-  }, [allV2PairsWithLiquidity, closedPositions, openPositions])
 
   if (!filteredPositions || loading) {
     return <PortfolioSkeleton />

--- a/apps/web/src/components/PositionCard/index.tsx
+++ b/apps/web/src/components/PositionCard/index.tsx
@@ -4,7 +4,7 @@ import { useWeb3React } from '@web3-react/core'
 import { Trans } from 'i18n'
 import JSBI from 'jsbi'
 import { transparentize } from 'polished'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'react-feather'
 import { Link } from 'react-router-dom'
 import { Text } from 'rebass'
@@ -157,13 +157,22 @@ export function MinimalPositionCard({ pair, showUnwrapped = false, border }: Pos
   )
 }
 
-export default function FullPositionCard({ pair, border, stakedBalance }: PositionCardProps) {
+export default function FullPositionCard({
+  pair,
+  border,
+  stakedBalance,
+  show = false,
+}: PositionCardProps & { show: boolean }) {
   const { account } = useWeb3React()
 
   const currency0 = unwrappedToken(pair.token0)
   const currency1 = unwrappedToken(pair.token1)
 
-  const [showMore, setShowMore] = useState(false)
+  const [showMore, setShowMore] = useState(show)
+
+  useEffect(() => {
+    setShowMore(show)
+  }, [show])
 
   const userDefaultPoolBalance = useTokenBalance(account ?? undefined, pair.liquidityToken)
   const totalPoolTokens = useTotalSupply(pair.liquidityToken)

--- a/apps/web/src/pages/Pool/v2.tsx
+++ b/apps/web/src/pages/Pool/v2.tsx
@@ -93,7 +93,6 @@ export default function Pool() {
   const [searchParams] = useSearchParams()
   const [highlight, setHighlight] = useState(searchParams.get('highlight')?.split('/') ?? [undefined, undefined])
   useEffect(() => {
-    console.log('here')
     setHighlight(searchParams.get('highlight')?.split('/') ?? [undefined, undefined])
   }, [searchParams])
 

--- a/apps/web/src/pages/Pool/v2.tsx
+++ b/apps/web/src/pages/Pool/v2.tsx
@@ -14,6 +14,7 @@ import { Text } from 'rebass'
 import styled, { useTheme } from 'styled-components'
 import { ExternalLink, HideSmall, ThemedText } from 'theme/components'
 import { ProtocolVersion } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
+
 import { ButtonOutlined, ButtonPrimary, ButtonSecondary } from '../../components/Button'
 import Card from '../../components/Card'
 import { AutoColumn } from '../../components/Column'

--- a/apps/web/src/pages/Pool/v2.tsx
+++ b/apps/web/src/pages/Pool/v2.tsx
@@ -7,9 +7,9 @@ import { useNetworkSupportsV2 } from 'hooks/useNetworkSupportsV2'
 import { Trans } from 'i18n'
 import JSBI from 'jsbi'
 import { PoolVersionMenu } from 'pages/Pool/shared'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronsRight } from 'react-feather'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { Text } from 'rebass'
 import styled, { useTheme } from 'styled-components'
 import { ExternalLink, HideSmall, ThemedText } from 'theme/components'
@@ -89,6 +89,13 @@ export default function Pool() {
   const theme = useTheme()
   const { account } = useWeb3React()
   const networkSupportsV2 = useNetworkSupportsV2()
+
+  const [searchParams] = useSearchParams()
+  const [highlight, setHighlight] = useState(searchParams.get('highlight')?.split('/') ?? [undefined, undefined])
+  useEffect(() => {
+    console.log('here')
+    setHighlight(searchParams.get('highlight')?.split('/') ?? [undefined, undefined])
+  }, [searchParams])
 
   // fetch the user's balances of all tracked V2 LP tokens
   let trackedTokenPairs = useTrackedTokenPairs()
@@ -241,7 +248,11 @@ export default function Pool() {
                       </RowBetween>
                     </ButtonSecondary>
                     {v2PairsWithoutStakedAmount.map((v2Pair) => (
-                      <FullPositionCard key={v2Pair.liquidityToken.address} pair={v2Pair} />
+                      <FullPositionCard
+                        key={v2Pair.liquidityToken.address}
+                        pair={v2Pair}
+                        show={v2Pair.token0.address === highlight[0] && v2Pair.token1.address === highlight[1]}
+                      />
                     ))}
                     {stakingPairs.map(
                       (stakingPair, i) =>
@@ -250,6 +261,10 @@ export default function Pool() {
                             key={stakingInfosWithBalance[i].stakingRewardAddress}
                             pair={stakingPair[1]}
                             stakedBalance={stakingInfosWithBalance[i].stakedAmount}
+                            show={
+                              stakingPair[1].token0.address === highlight[0] &&
+                              stakingPair[1].token1.address === highlight[1]
+                            }
                           />
                         )
                     )}


### PR DESCRIPTION
Closes #3 

# Description

Added support for displaying v2 pairs in the drawer.
If a user has liquidity in v2 pairs, they are displayed in an accordion element with a open state set as `true`.
Clicking on a pair opens the v2 pools page with a highlight query parameter, which focuses on the selected pair.